### PR TITLE
Update 4.扫描.md

### DIFF
--- a/content/4.扫描.md
+++ b/content/4.扫描.md
@@ -340,17 +340,17 @@ class Token {
 
 > Now that we know what we’re trying to produce, let’s, well, produce it. The core of the scanner is a loop. Starting at the first character of the source code, it figures out what lexeme it belongs to, and consumes it and any following characters that are part of that lexeme. When it reaches the end of that lexeme, it emits a token.
 
-既然我们已知道我们要输出的什么，那么，我们就开始吧。扫描器的核心是一个循环。从源码的第一个字符开始，扫描器计算出该字符属于哪个词素，并消费它和属于该词素的任何后续字符。当到达该词素的末尾时，扫描器会输出一个令牌。
+既然我们已知道我们要输出的什么，那么，我们就开始吧。扫描器的核心是一个循环。从源码的第一个字符开始，扫描器计算出该字符属于哪个词素，并消费它和属于该词素的任何后续字符。当到达该词素的末尾时，扫描器会输出一个标记（词法单元 token）。
 
 > Then it loops back and does it again, starting from the very next character in the source code. It keeps doing that, eating characters and occasionally, uh, excreting tokens, until it reaches the end of the input.
 
-然后再循环一次，它又循环回来，从源代码中的下一个字符开始再做一次。它一直这样做，吃掉字符，偶尔，呃，排出令牌，直到它到达输入的终点。
+然后再循环一次，它又循环回来，从源代码中的下一个字符开始再做一次。它一直这样做，吃掉字符，偶尔，呃，排出标记，直到它到达输入的终点。
 
 ![An alligator eating characters and, well, you don't want to know.](4.扫描/lexigator.png)
 
 > The part of the loop where we look at a handful of characters to figure out which kind of lexeme it “matches” may sound familiar. If you know regular expressions, you might consider defining a regex for each kind of lexeme and using those to match characters. For example, Lox has the same rules as C for identifiers (variable names and the like). This regex matches one:
 
-在循环中，我们会查看一些字符，以确定它 "匹配 "的是哪种词素，这部分内容可能听起来很熟悉，但如果你知道正则表达式，你可以考虑为每一种词素定义一个regex，并使用这些regex来匹配字符。如果你了解正则表达式，你可以考虑为每一种词素定义一个regex，然后用来匹配字符。例如，Lox对标识符（变量名等）的规则与C语言相同。下面的regex可以匹配一个标识符：
+在循环中，我们会查看一些字符，以确定它 "匹配 "的是哪种词素，这部分内容可能听起来很熟悉，但如果你知道正则表达式，你可以考虑为每一种词素定义一个regex，并使用这些regex来匹配字符。例如，Lox对标识符（变量名等）的规则与C语言相同。下面的regex可以匹配一个标识符：
 
 ```js
 [a-zA-Z_][a-zA-Z_0-9]*
@@ -358,7 +358,7 @@ class Token {
 
 > If you did think of regular expressions, your intuition is a deep one. The rules that determine how a particular language groups characters into lexemes are called its **lexical grammar**. In Lox, as in most programming languages, the rules of that grammar are simple enough for the language to be classified a **[regular language](https://en.wikipedia.org/wiki/Regular_language)**. That’s the same “regular” as in regular expressions.
 
-如果你确实想到了正则表达式，那么你的直觉还是很深刻的。决定一门语言如何将字符分组为词素的规则被称为它的**词法语法**[^8]。在Lox中，和大多数编程语言一样，该语法的规则非常简单，可以将其归为**[正则语言](https://en.wikipedia.org/wiki/Regular_language)**。这里的正则和正则表达式中的 "正则 "是一样的含义。
+如果你确实想到了正则表达式，那么你的直觉还是很深刻的。决定一门语言如何将字符分组为词素的规则被称为它的**词法语法**[^8]。在Lox中，和大多数编程语言一样，该语法的规则非常简单，可以将其归为 **[正则语言](https://en.wikipedia.org/wiki/Regular_language)**。这里的正则和正则表达式中的 "正则 "是一样的含义。
 
 > You very precisely *can* recognize all of the different lexemes for Lox using regexes if you want to, and there’s a pile of interesting theory underlying why that is and what it means. Tools like [Lex](http://dinosaur.compilertools.net/lex/) or [Flex](https://github.com/westes/flex) are designed expressly to let you do this—throw a handful of regexes at them, and they give you a complete scanner back.
 
@@ -455,7 +455,7 @@ class Scanner {
 
 > In each turn of the loop, we scan a single token. This is the real heart of the scanner. We’ll start simple. Imagine if every lexeme were only a single character long. All you would need to do is consume the next character and pick a token type for it. Several lexemes *are* only a single character in Lox, so let’s start with those.
 
-在每一次循环中，我们会扫描一个标记。这是扫描器真正的核心。让我们先从简单情况开始。想象一下，如果每个词素只有一个字符长。您所需要做的就是消费下一个字符并为其选择一个令牌类型。在Lox中有一些词素只包含一个字符，所有我们从这些词素开始[^11]。
+在每一次循环中，我们可以扫描出一个 token。这是扫描器真正的核心。让我们先从简单情况开始。想象一下，如果每个词素只有一个字符长。您所需要做的就是消费下一个字符并为其选择一个 token 类型。在Lox中有一些词素只包含一个字符，所有我们从这些词素开始[^11]。
 
 *<u>lox/Scanner.java添加到scanTokens()方法之后</u>*
 
@@ -501,7 +501,7 @@ private void scanToken() {
 
 > The `advance()` method consumes the next character in the source file and returns it. Where `advance()` is for input, `addToken()` is for output. It grabs the text of the current lexeme and creates a new token for it. We’ll use the other overload to handle tokens with literal values soon.
 
-`advance()`方法获取源文件中的下一个字符并返回它。`advance()`用于处理输入，`addToken()`则用于输出。该方法获取当前词素的文本并为其创建一个新标记。我们马上会使用另一个重载方法来处理带有字面值的标记。
+`advance()`方法获取源文件中的下一个字符并返回它。`advance()`用于处理输入，`addToken()`则用于输出。该方法获取当前词素的文本并为其创建一个新 token。我们马上会使用另一个重载方法来处理带有字面值的 token。
 
 > ### 4 . 5 . 1 Lexical errors
 


### PR DESCRIPTION
1. 删除一个冗余的句子
2. token 的翻译比较多样化（标记、令牌、词法单元），建议直接使用 token 避免歧义。
3. 修改到的部分，参考了中文排版进行了微调（主要是空格）
    - https://github.com/mzlogin/chinese-copywriting-guidelines