### PR TITLE
fix:第三章翻译润色

### DIFF
--- a/content/3.Lox语言.md
+++ b/content/3.Lox语言.md
@@ -566,7 +566,7 @@ fn();
 
 > I could claim objects are groovy but still out of scope for the book. Most programming language books, especially ones that try to implement a whole language, leave objects out. To me, that means the topic isn’t well covered. With such a widespread paradigm, that omission makes me sad.
 
-我可以声明对象是groovy的，但仍然超出了本书的范围。大多数编程语言的书籍，特别是那些试图实现一门完整语言的书籍，都忽略了对象。对我来说，这意味着这个主题没有被很好地覆盖。对于如此广泛使用的范式，这种遗漏让我感到悲伤。
+我可以说对象确实很吸引人，但仍然超出了本书的范围。大多数编程语言的书籍，特别是那些试图实现一门完整语言的书籍，都忽略了对象。对我来说，这意味着这个主题没有被很好地覆盖。对于如此广泛使用的范式，这种遗漏让我感到悲伤。
 
 > Given how many of us spend all day *using* OOP languages, it seems like the world could use a little documentation on how to *make* one. As you’ll see, it turns out to be pretty interesting. Not as hard as you might fear, but not as simple as you might presume, either.
 

--- a/content/3.Lox语言.md
+++ b/content/3.Lox语言.md
@@ -579,7 +579,7 @@ fn();
 
 > When it comes to objects, there are actually two approaches to them, [classes](https://en.wikipedia.org/wiki/Class-based_programming) and [prototypes](https://en.wikipedia.org/wiki/Prototype-based_programming). Classes came first, and are more common thanks to C++, Java, C#, and friends. Prototypes were a virtually forgotten offshoot until JavaScript accidentally took over the world.
 
-当涉及对象时，实际上有两种方法，类和原型。 类最先出现，由于C++、Java、C#和其它近似语言的出现，类更加普遍。直到JavaScript意外地占领了世界之前，原型几乎是一个被遗忘的分支。
+当涉及对象时，实际上有两种方法，[类](https://en.wikipedia.org/wiki/Class-based_programming)和[原型](https://en.wikipedia.org/wiki/Prototype-based_programming)。 类最先出现，由于C++、Java、C#和其它近似语言的出现，类更加普遍。直到JavaScript意外地占领了世界之前，原型几乎是一个被遗忘的分支。
 
 > In a class-based language, there are two core concepts: instances and classes. Instances store the state for each object and have a reference to the instance’s class. Classes contain the methods and inheritance chain. To call a method on an instance, there is always a level of indirection. You look up the instance’s class and then you find the method *there*:
 

--- a/content/3.Lox语言.md
+++ b/content/3.Lox语言.md
@@ -758,7 +758,7 @@ class Brunch < Breakfast {
 
 > This is the saddest part of Lox. Its standard library goes beyond minimalism and veers close to outright nihilism. For the sample code in the book, we only need to demonstrate that code is running and doing what it’s supposed to do. For that, we already have the built-in `print` statement.
 
-这是Lox中最可悲的部分。它的标准库已经超过了极简主义，解决彻底的虚无主义。对于本书中的示例代码，我们只需要证明代码在运行，并且在做它应该做的事。为此，我们已经有了内置的`print`语句。
+这是Lox中最可悲的部分。它的标准库已经超过了极简主义，接近彻底的虚无主义。对于本书中的示例代码，我们只需要证明代码在运行，并且在做它应该做的事。为此，我们已经有了内置的`print`语句。
 
 > Later, when we start optimizing, we’ll write some benchmarks and see how long it takes to execute code. That means we need to track time, so we’ll define one built-in function `clock()` that returns the number of seconds since the program started.
 


### PR DESCRIPTION
1. groovy这里应该被翻译为"吸引人"
2. 增加了对维基百科的链接
3. `解决彻底的虚无主义`  -> `接近彻底的虚无主义`