### PR TITLE
[Fix] 17 . 4 . 1 Parsers for tokens

### DIFF
--- a/content/17.编译表达式.md
+++ b/content/17.编译表达式.md
@@ -537,7 +537,7 @@ static void expression() {
 
 > For now, let’s focus on the Lox expressions that are each only a single token. In this chapter, that’s just number literals, but there will be more later. Here’s how we can compile them:
 
-现在，让我们把注意力集中在仅有三个标识的Lox表达式上。在本章中，这只包括数值字面量，但后面会有更多。下面是我们如何编译它们：
+现在，让我们把注意力集中在那些只由单个 token 组成的Lox表达式上。在本章中，这只包括数值字面量，但后面会有更多。下面是我们如何编译它们：
 
 > We map each token type to a different kind of expression. We define a function for each expression that outputs the appropriate bytecode. Then we build an array of function pointers. The indexes in the array correspond to the `TokenType` enum values, and the function at each index is the code to compile an expression of that token type.
 


### PR DESCRIPTION
1. [Errata] 一处翻译勘误
2. [Proposal] 本书的中文翻译里 token 的对应翻译词太多，我看见过的就有三种：
- 标识（本书大多数地方）
- 词法标识（17.2 节中）
- 令牌（17.2.1 节中） 
建议是否可以统一改为 token 或者 词法单元（龙书的翻译）。

最后：感谢各位译者的翻译工作