### PR TITLE
[Fix] Ch.23.4 - a typo in for statements

### DIFF
--- a/content/23.来回跳转.md
+++ b/content/23.来回跳转.md
@@ -709,7 +709,7 @@ Lox中的另一个循环语句是古老的`for`循环，继承自C语言。与`w
 
 > It calls a helper function. If we only supported `for` loops with empty clauses like `for (;;)`, then we could implement it like this:
 
-它会调用一个辅助函数。如果我们只支持`for(::)`这样带有空子句的`for`循环，那么我们可以这样实现它：
+它会调用一个辅助函数。如果我们只支持`for(;;)`这样带有空子句的`for`循环，那么我们可以这样实现它：
 
 *<u>compiler.c，在expressionStatement()方法后添加代码：</u>*
 


### PR DESCRIPTION
[Fix] Chapter 23 . 4 For Statements - 一处勘误，空子句 for 循环中应该是分号

[Proposal] 本章中的 stack 翻译不统一，大多数是翻译为”堆栈“，有几处翻译为“栈”。是否考虑修改为”栈“更准确？
例如本章最后的设计笔记里：”换句话说，就是**调用栈 (a call stack)**，尽管我认为Dijkstra写这个的时候，这个术语还不存在。“